### PR TITLE
Upgrade navitia_model v0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["David Quintanel <david.quintanel@gmail.com>", "Nicolas Bérard <nico
 edition="2018"
 
 [dependencies]
-navitia_model = { git = "https://github.com/CanalTP/navitia_model", tag = "v0.2.0" }
+navitia_model = { git = "https://github.com/CanalTP/navitia_model", tag = "v0.3.0" }
 osm_transit_extractor = { git = "https://github.com/CanalTP/osm-transit-extractor", tag = "v0.1.2" }
 geo = { git = "https://github.com/georust/geo" }
 structopt = "0.2.10"
@@ -20,4 +20,5 @@ serde = "1.0.84"
 serde_derive = "1.0.84"
 osmpbfreader = "0.11"
 unidecode = "0.3.0"
+chrono = "0.4.0"
 [workspace]

--- a/src/bin/improve-stop-positions.rs
+++ b/src/bin/improve-stop-positions.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
+use chrono::NaiveDateTime;
 use log::info;
 use navitia_model::{ntfs, Model};
 use std::path::PathBuf;
@@ -42,6 +43,15 @@ struct Opt {
     // The min distance in meters to update the coordinates
     #[structopt(long, short = "d", default_value = "20")]
     min_distance: f64,
+
+    /// current datetime
+    #[structopt(
+        short = "x",
+        long,
+        parse(try_from_str),
+        raw(default_value = "&navitia_model::CURRENT_DATETIME")
+    )]
+    current_datetime: NaiveDateTime,
 }
 
 fn run() -> Result<()> {
@@ -52,7 +62,7 @@ fn run() -> Result<()> {
     let mut collections = model.into_collections();
     improve_stop_positions::improve_with_pbf(&opt.pbf, &mut collections, opt.min_distance)?;
     let model = Model::new(collections)?;
-    navitia_model::ntfs::write(&model, opt.output)?;
+    navitia_model::ntfs::write(&model, opt.output, opt.current_datetime)?;
 
     Ok(())
 }

--- a/src/bin/map-ntfs-with-osm.rs
+++ b/src/bin/map-ntfs-with-osm.rs
@@ -14,6 +14,7 @@
 // along with this program.  If not, see
 // <http://www.gnu.org/licenses/>.
 
+use chrono::NaiveDateTime;
 use failure::bail;
 use log::info;
 use navitia_model::ntfs;
@@ -48,6 +49,15 @@ struct Opt {
     /// force double matching between ntfs and osm stop_point
     #[structopt(short, long)]
     force_double_stop_point_matching: bool,
+
+    /// current datetime
+    #[structopt(
+        short = "x",
+        long,
+        parse(try_from_str),
+        raw(default_value = "&navitia_model::CURRENT_DATETIME")
+    )]
+    current_datetime: NaiveDateTime,
 }
 
 fn run() -> Result<()> {
@@ -72,7 +82,7 @@ fn run() -> Result<()> {
         ntfs_network_to_osm,
         opt.force_double_stop_point_matching,
     )?;
-    navitia_model::ntfs::write(&enriched_model, opt.output)?;
+    navitia_model::ntfs::write(&enriched_model, opt.output, opt.current_datetime)?;
 
     Ok(())
 }

--- a/tests/improve_stop_positions.rs
+++ b/tests/improve_stop_positions.rs
@@ -32,7 +32,7 @@ fn test_global() {
         )
         .unwrap();
         let model = Model::new(collections).unwrap();
-        ntfs::write(&model, path).unwrap();
+        ntfs::write(&model, path, get_test_datetime()).unwrap();
         compare_output_dir_with_expected(
             &path,
             Some(vec!["stops.txt"]),

--- a/tests/map_ntfs_with_osm.rs
+++ b/tests/map_ntfs_with_osm.rs
@@ -34,7 +34,7 @@ fn test_map_no_force() {
             false,
         )
         .unwrap();
-        navitia_model::ntfs::write(&enriched_model, path).unwrap();
+        navitia_model::ntfs::write(&enriched_model, path, get_test_datetime()).unwrap();
         compare_output_dir_with_expected(
             &path,
             Some(vec!["object_codes.txt"]),
@@ -57,7 +57,7 @@ fn test_map_force() {
             true,
         )
         .unwrap();
-        navitia_model::ntfs::write(&enriched_model, path).unwrap();
+        navitia_model::ntfs::write(&enriched_model, path, get_test_datetime()).unwrap();
         compare_output_dir_with_expected(
             &path,
             Some(vec!["object_codes.txt"]),


### PR DESCRIPTION
Can be used when https://github.com/CanalTP/navitia_model/pull/194 will be merged.
Just change the navitia_model tag (in Cargo.toml) with a version greater than v0.2.0.