### PR TITLE
Fix Error on missing poi_properties.txt

### DIFF
--- a/navitia-poi-model/src/io.rs
+++ b/navitia-poi-model/src/io.rs
@@ -102,27 +102,22 @@ where
     };
     // For poi_properties.txt, it's a bit different: If the file is not
     // present, it does not mean it is an error.
-    match zip.by_name("poi_properties.txt") {
-        Ok(zipper) => {
-            let reader = read_csv(zipper);
-            reader
-                .map(|rec| {
-                    let poi_property: PoiProperty = rec?;
-                    let poi = pois.get_mut(&poi_property.poi_id).ok_or_else(|| {
-                        format_err!(
-                            "in file '{}', cannot find poi '{}' for property insertion",
-                            path.as_ref().display(),
-                            &poi_property.poi_id
-                        )
-                    })?;
-                    poi.properties.push(Property::from(poi_property));
-                    Ok(())
-                })
-                .collect::<Result<()>>()?;
-        }
-        Err(_) => {
-            // Could not find poi_properties.txt... do nothing
-        }
+    if let Ok(zipper) = zip.by_name("poi_properties.txt") {
+        let reader = read_csv(zipper);
+        reader
+            .map(|rec| {
+                let poi_property: PoiProperty = rec?;
+                let poi = pois.get_mut(&poi_property.poi_id).ok_or_else(|| {
+                    format_err!(
+                        "in file '{}', cannot find poi '{}' for property insertion",
+                        path.as_ref().display(),
+                        &poi_property.poi_id
+                    )
+                })?;
+                poi.properties.push(Property::from(poi_property));
+                Ok(())
+            })
+            .collect::<Result<()>>()?;
     }
     Ok(Model { pois, poi_types })
 }

--- a/navitia-poi-model/src/io.rs
+++ b/navitia-poi-model/src/io.rs
@@ -100,22 +100,30 @@ where
             })
             .collect::<Result<_>>()?
     };
-    let zipper = zip.by_name("poi_properties.txt")?;
-    let reader = read_csv(zipper);
-    reader
-        .map(|rec| {
-            let poi_property: PoiProperty = rec?;
-            let poi = pois.get_mut(&poi_property.poi_id).ok_or_else(|| {
-                format_err!(
-                    "in file '{}', cannot find poi '{}' for property insertion",
-                    path.as_ref().display(),
-                    &poi_property.poi_id
-                )
-            })?;
-            poi.properties.push(Property::from(poi_property));
-            Ok(())
-        })
-        .collect::<Result<()>>()?;
+    // For poi_properties.txt, it's a bit different: If the file is not
+    // present, it does not mean it is an error.
+    match zip.by_name("poi_properties.txt") {
+        Ok(zipper) => {
+            let reader = read_csv(zipper);
+            reader
+                .map(|rec| {
+                    let poi_property: PoiProperty = rec?;
+                    let poi = pois.get_mut(&poi_property.poi_id).ok_or_else(|| {
+                        format_err!(
+                            "in file '{}', cannot find poi '{}' for property insertion",
+                            path.as_ref().display(),
+                            &poi_property.poi_id
+                        )
+                    })?;
+                    poi.properties.push(Property::from(poi_property));
+                    Ok(())
+                })
+                .collect::<Result<()>>()?;
+        }
+        Err(_) => {
+            // Could not find poi_properties.txt... do nothing
+        }
+    }
     Ok(Model { pois, poi_types })
 }
 


### PR DESCRIPTION
When working on a '.poi' file, it is not an error if there is
no 'poi_properties.txt'.